### PR TITLE
Scala 2.12 support

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/Model.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/Model.scala
@@ -69,6 +69,8 @@ case class ScalaVersion(value: String) {
 }
 
 object ScalaVersions {
+  val v2_13 = ScalaVersion("2.13")
+
   val v2_12 = ScalaVersion("2.12")
 
   val v2_11 = ScalaVersion("2.11")
@@ -76,6 +78,6 @@ object ScalaVersions {
   /**
     * This list require to have older version in later positions
     */
-  val all = List(v2_12, v2_11)
+  val all = List(v2_13, v2_12, v2_11)
 
 }

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/Model.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/Model.scala
@@ -63,3 +63,19 @@ case class AppConfigBaseFileName(repositoryName: RepositoryName) {
 case class SlugRuntimeJavaOpts(value : String) {
   override def toString: String = value
 }
+
+case class ScalaVersion(value: String) {
+  override def toString: String = value
+}
+
+object ScalaVersions {
+  val v2_12 = ScalaVersion("2.12")
+
+  val v2_11 = ScalaVersion("2.11")
+
+  /**
+    * This list require to have older version in later positions
+    */
+  val all = List(v2_12, v2_11)
+
+}

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/connectors/ArtifactoryConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/connectors/ArtifactoryConnector.scala
@@ -95,9 +95,11 @@ class ArtifactoryConnector(
               loop(Right(s"Successfully downloaded artifact from $url"), tail)
           }
 
-        case (Left(errors), Nil) => Left("Could not find artifact: Caused by" + errors.mkString("\n\t", "\n\t", "\n"))
+        case (Left(errors), Nil) =>
+          Left("Could not find artifact. Caused by" + errors.mkString("\n\t", "\n\t", "\n"))
 
-        case (Right(message), Nil) => Right(message)
+        case (Right(message), Nil) =>
+          Right(message)
       }
     }
     loop(Left(Seq.empty), ScalaVersions.all)

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/connectors/ArtifactoryConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/connectors/ArtifactoryConnector.scala
@@ -23,6 +23,7 @@ import play.api.libs.ws.DefaultBodyWritables._
 import play.api.libs.ws._
 import uk.gov.hmrc.slugbuilder._
 
+import scala.annotation.tailrec
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -73,6 +74,7 @@ class ArtifactoryConnector(
 
     def targetFileName(scalaVersion: ScalaVersion) = DestinationFileName(s"${artifactFileName}_${scalaVersion}")
 
+    @tailrec
     def loop(outcome: Either[Seq[String], String], scalaVersions: List[ScalaVersion]): Either[String, String] = {
       (outcome, scalaVersions) match {
         case (prev@Right(msg), scalaVersion :: tail) =>
@@ -82,7 +84,7 @@ class ArtifactoryConnector(
             case Left(_) =>
               loop(prev, tail)
             case Right(_) =>
-              Left(s"Multiple version of scala artifact match - also in $scalaVersion. Caused by $prev")
+              Left(s"Multiple artifact versions found - also in $scalaVersion. Caused by $prev")
           }
         case (Left(errors), scalaVersion :: tail) =>
           val target = targetFileName(scalaVersion)

--- a/src/test/scala/uk/gov/hmrc/slugbuilder/connectors/ArtifactoryConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/slugbuilder/connectors/ArtifactoryConnectorSpec.scala
@@ -34,7 +34,7 @@ import uk.gov.hmrc.slugbuilder.{AppConfigBaseFileName, ArtifactFileName, ScalaVe
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class ArtifactoryConnectorSpec extends WordSpec with MockFactory with ScalaFutures with Matchers with BeforeAndAfter with EitherValues {
+class ArtifactoryConnectorSpec extends WordSpec with MockFactory with ScalaFutures with Matchers with BeforeAndAfterAll with EitherValues {
 
   "verifySlugNotCreatedYet" should {
 
@@ -403,8 +403,8 @@ class ArtifactoryConnectorSpec extends WordSpec with MockFactory with ScalaFutur
 
   var files: List[Path] = Nil
 
-  override protected def after(fun: => Any)(implicit pos: Position): Unit = {
+  override protected def afterAll(): Unit = {
     files.foreach(Files.deleteIfExists)
-    super.after(fun)
+    super.afterAll()
   }
 }


### PR DESCRIPTION
This implementation address lack of support for non 2.11 artefacts.
With probing we don't need to change anything in build system or adding additional parameters to slug builders.

There is slightly change in messages. Now error on downloading artefact contains information about all tried URLs and their outcomes.