### PR TITLE
BDOG 301 Add build.properties file to slug

### DIFF
--- a/src/main/scala/uk/gov/hmrc/slugbuilder/EnvironmentVariables.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/EnvironmentVariables.scala
@@ -20,15 +20,17 @@ import cats.implicits._
 
 object EnvironmentVariables {
 
+  val all: Map[String, String]                    = sys.env
   val artifactoryUri: Either[String, String]      = findVariable("ARTIFACTORY_URI")
   val artifactoryUsername: Either[String, String] = findVariable("ARTIFACTORY_USERNAME")
   val artifactoryPassword: Either[String, String] = findVariable("ARTIFACTORY_PASSWORD")
   val slugRunnerVersion: Either[String, String]   = findVariable("SLUG_RUNNER_VERSION")
   val jdkFileName: Either[String, String]         = findVariable("JDK_FILE_NAME")
-  val slugRuntimeJavaOpts: Option[SlugRuntimeJavaOpts]      = findVariable("SLUG_RUNTIME_JAVA_OPTS").toOption.map(SlugRuntimeJavaOpts)
+  val slugRuntimeJavaOpts: Option[SlugRuntimeJavaOpts] =
+    findVariable("SLUG_RUNTIME_JAVA_OPTS").toOption.map(SlugRuntimeJavaOpts)
 
   private def findVariable(name: String): Either[String, String] = Either.fromOption(
-    sys.env.get(name),
+    all.get(name),
     ifNone = s"No '$name' environment variable found"
   )
 }

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/Main.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/Main.scala
@@ -27,21 +27,21 @@ import scala.language.postfixOps
 
 object Main {
 
-  private lazy val slugRunnerVersion   = EnvironmentVariables.slugRunnerVersion.getOrExit
-  private lazy val artifactoryUri      = EnvironmentVariables.artifactoryUri.getOrExit
-  private lazy val artifactoryUsername = EnvironmentVariables.artifactoryUsername.getOrExit
-  private lazy val artifactoryPassword = EnvironmentVariables.artifactoryPassword.getOrExit
-  private lazy val jdkFileName         = EnvironmentVariables.jdkFileName.getOrExit
-  private lazy val slugRuntimeJavaOpts = EnvironmentVariables.slugRuntimeJavaOpts
-  private val environmentVariables     = EnvironmentVariables.all
+  private val slugRunnerVersion    = EnvironmentVariables.slugRunnerVersion.getOrExit
+  private val artifactoryUri       = EnvironmentVariables.artifactoryUri.getOrExit
+  private val artifactoryUsername  = EnvironmentVariables.artifactoryUsername.getOrExit
+  private val artifactoryPassword  = EnvironmentVariables.artifactoryPassword.getOrExit
+  private val jdkFileName          = EnvironmentVariables.jdkFileName.getOrExit
+  private val slugRuntimeJavaOpts  = EnvironmentVariables.slugRuntimeJavaOpts
+  private val environmentVariables = EnvironmentVariables.all
 
-  private lazy implicit val system: ActorSystem    = ActorSystem()
-  private lazy implicit val mat: ActorMaterializer = ActorMaterializer()
+  private implicit val system: ActorSystem    = ActorSystem()
+  private implicit val mat: ActorMaterializer = ActorMaterializer()
 
-  private lazy val progressReporter = new ProgressReporter()
-  private lazy val httpClient       = StandaloneAhcWSClient()
-  private lazy val fileDownloader   = new FileDownloader(httpClient)
-  private lazy val artifactoryConnector =
+  private val progressReporter = new ProgressReporter()
+  private val httpClient       = StandaloneAhcWSClient()
+  private val fileDownloader   = new FileDownloader(httpClient)
+  private val artifactoryConnector =
     new ArtifactoryConnector(
       httpClient,
       fileDownloader,

--- a/src/test/scala/uk/gov/hmrc/slugbuilder/SlugBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/slugbuilder/SlugBuilderSpec.scala
@@ -17,11 +17,10 @@
 package uk.gov.hmrc.slugbuilder
 
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.Paths
 import java.nio.file.StandardOpenOption.CREATE_NEW
 import java.nio.file.attribute.PosixFilePermission._
+import java.nio.file.{Path, Paths}
 
-import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.{doThrow, verify, when}
 import org.scalatest.Matchers._
@@ -42,7 +41,7 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
       "app-config-base can be downloaded and " +
       "a slug file is assembled" in new Setup {
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('right)
+      slugBuilder.create(repositoryName, releaseVersion, None, Map("a" -> "b", "c" -> "d")) should be('right)
 
       progressReporter.logs should contain("Slug does not exist")
       progressReporter.logs should contain("Artifact downloaded")
@@ -64,12 +63,14 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
 
       verify(fileUtils).createFile(procFile, "web: ./start-docker.sh", UTF_8, CREATE_NEW)
 
+      verify(fileUtils).createFile(buildPropertiesFile, "a=b\nc=d", UTF_8, CREATE_NEW)
+
       verify(fileUtils).createDir(slugDirectory.resolve(".jdk"))
 
-      val profileD = slugDirectory.resolve(".profile.d")
+      val profileD: Path = slugDirectory.resolve(".profile.d")
       verify(fileUtils).createDir(profileD)
 
-      val javaSh = profileD resolve "java.sh"
+      val javaSh: Path = profileD resolve "java.sh"
       verify(fileUtils)
         .createFile(javaSh, "PATH=$HOME/.jdk/bin:$PATH\nJAVA_HOME=$HOME/.jdk/", UTF_8, CREATE_NEW)
     }
@@ -78,10 +79,14 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
       "slug for the given version of the microservice does not exist and " +
       "microservice artifact can be downloaded and " +
       "app-config-base can be downloaded and " +
-      "a slug file is assembled"
+      "a slug file is assembled" +
       "and custom JAVA_OPTS property has been provided" in new Setup {
 
-      slugBuilder.create(repositoryName, releaseVersion, Some(SlugRuntimeJavaOpts("-Xmx256"))) should be('right)
+      slugBuilder.create(
+        repositoryName,
+        releaseVersion,
+        Some(SlugRuntimeJavaOpts("-Xmx256")),
+        Map("a" -> "b", "c" -> "d")) should be('right)
 
       progressReporter.logs should contain("Slug does not exist")
       progressReporter.logs should contain("Artifact downloaded")
@@ -92,7 +97,10 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
       progressReporter.logs should contain("Slug published successfully to https://artifactory/some-slug.tgz")
       progressReporter.logs should contain("Successfully created .profile.d/java.sh")
 
-      verify(startDockerScriptCreator).ensureStartDockerExists(workspaceDirectory, slugDirectory, repositoryName,
+      verify(startDockerScriptCreator).ensureStartDockerExists(
+        workspaceDirectory,
+        slugDirectory,
+        repositoryName,
         Some(SlugRuntimeJavaOpts("-Xmx256")))
 
       verify(fileUtils).createDir(slugDirectory)
@@ -104,23 +112,24 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
 
       verify(fileUtils).createFile(procFile, "web: ./start-docker.sh", UTF_8, CREATE_NEW)
 
+      verify(fileUtils).createFile(buildPropertiesFile, "a=b\nc=d", UTF_8, CREATE_NEW)
+
       verify(fileUtils).createDir(slugDirectory.resolve(".jdk"))
 
-      val profileD = slugDirectory.resolve(".profile.d")
+      val profileD: Path = slugDirectory.resolve(".profile.d")
       verify(fileUtils).createDir(profileD)
 
-      val javaSh = profileD resolve "java.sh"
+      val javaSh: Path = profileD resolve "java.sh"
       verify(fileUtils)
         .createFile(javaSh, "PATH=$HOME/.jdk/bin:$PATH\nJAVA_HOME=$HOME/.jdk/", UTF_8, CREATE_NEW)
     }
-
 
     "not create the slug if it already exists in the Webstore" in new Setup {
       when(artifactConnector.verifySlugNotCreatedYet(repositoryName, releaseVersion))
         .thenReturn(Left("Slug does exist"))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
-      progressReporter.logs                              should contain("Slug does exist")
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
+      progressReporter.logs                                               should contain("Slug does exist")
     }
 
     "not create the slug if there is no artifact in the Artifactory" in new Setup {
@@ -130,8 +139,8 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
           .downloadArtifact(repositoryName, releaseVersion, ArtifactFileName(repositoryName, releaseVersion)))
         .thenReturn(Left("Artifact does not exist"))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
-      progressReporter.logs                              should contain("Artifact does not exist")
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
+      progressReporter.logs                                               should contain("Artifact does not exist")
     }
 
     "not create the slug if there is app-config-base in the Webstore" in new Setup {
@@ -139,8 +148,8 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
       when(artifactConnector.downloadAppConfigBase(repositoryName))
         .thenReturn(Left("app-config-base does not exist"))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
-      progressReporter.logs                              should contain("app-config-base does not exist")
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
+      progressReporter.logs                                               should contain("app-config-base does not exist")
     }
 
     "return error message when slug directory cannot be created" in new Setup {
@@ -148,7 +157,7 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
       val exception = new RuntimeException("exception message")
       doThrow(exception).when(fileUtils).createDir(slugDirectory)
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
       progressReporter.logs should contain(
         s"Couldn't create slug directory at ${slugDirectory.toFile.getName}. Cause: ${exception.getMessage}")
     }
@@ -157,8 +166,8 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
       when(tarArchiver.decompress(artifactFile, slugDirectory))
         .thenReturn(Left("Some error"))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
-      progressReporter.logs                              should contain("Some error")
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
+      progressReporter.logs                                               should contain("Some error")
     }
 
     "return error when start-docker.sh creation return left" in new Setup {
@@ -167,8 +176,8 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
       when(startDockerScriptCreator.ensureStartDockerExists(workspaceDirectory, slugDirectory, repositoryName, None))
         .thenReturn(Left(errorMessage))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
-      progressReporter.logs                              should contain("error message")
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
+      progressReporter.logs                                               should contain("error message")
     }
 
     "return error when start-docker.sh permissions cannot be changed" in new Setup {
@@ -179,7 +188,7 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
           startDockerFile,
           Set(OWNER_EXECUTE, OWNER_READ, OWNER_WRITE, GROUP_EXECUTE, GROUP_READ, OTHERS_EXECUTE, OTHERS_READ))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
       progressReporter.logs should contain(
         s"Couldn't change permissions of the $startDockerFile. Cause: ${exception.getMessage}")
     }
@@ -188,15 +197,15 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
       val exception = new RuntimeException("exception message")
       doThrow(exception).when(fileUtils).createFile(procFile, "web: ./start-docker.sh", UTF_8, CREATE_NEW)
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
-      progressReporter.logs                              should contain(s"Couldn't create the $procFile. Cause: ${exception.getMessage}")
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
+      progressReporter.logs                                               should contain(s"Couldn't create the $procFile. Cause: ${exception.getMessage}")
     }
 
     "return error if creating the .jdk directory fails" in new Setup {
       val exception = new RuntimeException("exception message")
       doThrow(exception).when(fileUtils).createDir(slugDirectory.resolve(".jdk"))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
       progressReporter.logs should contain(
         s"Couldn't create .jdk directory at $slugDirectory/.jdk. Cause: ${exception.getMessage}")
     }
@@ -205,8 +214,8 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
       when(artifactConnector.downloadJdk(jdkFileName))
         .thenReturn(Left("Error downloading JDK"))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
-      progressReporter.logs                              should contain("Error downloading JDK")
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
+      progressReporter.logs                                               should contain("Error downloading JDK")
     }
 
     "return error message when the JDK cannot be extracted" in new Setup {
@@ -214,45 +223,46 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
       when(tarArchiver.decompress(Paths.get(jdkFileName), slugDirectory.resolve(".jdk")))
         .thenReturn(Left("Some error"))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
-      progressReporter.logs                              should contain("Some error")
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
+      progressReporter.logs                                               should contain("Some error")
     }
 
     "return error message when the Slug cannot be compressed" in new Setup {
       when(tarArchiver.compress(slugTgzFile, slugDirectory))
         .thenReturn(Left("Some error"))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
-      progressReporter.logs                              should contain(s"Some error")
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
+      progressReporter.logs                                               should contain(s"Some error")
     }
 
     "return error message when the Slug cannot be published" in new Setup {
       when(artifactConnector.publish(repositoryName, releaseVersion))
         .thenReturn(Left("Some error"))
 
-      slugBuilder.create(repositoryName, releaseVersion, None) should be('left)
-      progressReporter.logs                              should contain(s"Some error")
+      slugBuilder.create(repositoryName, releaseVersion, None, Map.empty) should be('left)
+      progressReporter.logs                                               should contain(s"Some error")
     }
 
     "not catch fatal Errors" in new Setup {
       val error = new OutOfMemoryError("error")
       doThrow(error).when(fileUtils).createDir(slugDirectory)
 
-      intercept[Throwable](slugBuilder.create(repositoryName, releaseVersion, None)) shouldBe error
+      intercept[Throwable](slugBuilder.create(repositoryName, releaseVersion, None, Map.empty)) shouldBe error
     }
 
   }
 
   private trait Setup {
-    val repositoryName     = repositoryNameGen.generateOne
-    val releaseVersion     = releaseVersionGen.generateOne
-    val artifactFile       = Paths.get(ArtifactFileName(repositoryName, releaseVersion).toString)
-    val workspaceDirectory = Paths.get(".")
-    val slugDirectory      = Paths.get("slug")
-    val startDockerFile    = slugDirectory resolve "start-docker.sh"
-    val procFile           = slugDirectory resolve "Procfile"
-    val slugRunnerVersion  = "0.5.2"
-    val slugTgzFile        = Paths.get(s"${repositoryName}_${releaseVersion}_$slugRunnerVersion.tgz")
+    val repositoryName      = repositoryNameGen.generateOne
+    val releaseVersion      = releaseVersionGen.generateOne
+    val artifactFile        = Paths.get(ArtifactFileName(repositoryName, releaseVersion).toString)
+    val workspaceDirectory  = Paths.get(".")
+    val slugDirectory       = Paths.get("slug")
+    val startDockerFile     = slugDirectory resolve "start-docker.sh"
+    val procFile            = slugDirectory resolve "Procfile"
+    val buildPropertiesFile = slugDirectory resolve "build.properties"
+    val slugRunnerVersion   = "0.5.2"
+    val slugTgzFile         = Paths.get(s"${repositoryName}_${releaseVersion}_$slugRunnerVersion.tgz")
 
     val progressReporter = new ProgressReporter {
 
@@ -294,8 +304,9 @@ class SlugBuilderSpec extends WordSpec with MockitoSugar {
     when(tarArchiver.decompress(artifactFile, slugDirectory))
       .thenReturn(Right(s"Successfully decompressed $artifactFile"))
 
-    when(startDockerScriptCreator.ensureStartDockerExists(
-      meq(workspaceDirectory), meq(slugDirectory), meq(repositoryName), any()))
+    when(
+      startDockerScriptCreator
+        .ensureStartDockerExists(meq(workspaceDirectory), meq(slugDirectory), meq(repositoryName), any()))
       .thenReturn(Right("Created new start-docker.sh script"))
 
     when(artifactConnector.downloadJdk(jdkFileName))


### PR DESCRIPTION
These changes will allow us to know what properties have been specified during the build process. This will allow us to get a hold of useful information such as what java version has been packaged into the slug.