### PR TITLE
BDOG-508 Enable copying additional files into slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ This is a tool to be used in command line to create and publish *slug* artifacts
 
 # How to create and publish a slug?
 
-In order to make the tool working, following variables have to set in the running environment: 
-* JAVA_VERSION
-* ARTIFACTORY_URI
-* WEBSTORE_URI
-* SLUG_RUNNER_VERSION
-* GITHUB_API_USER
-* GITHUB_API_TOKEN
+The following environment variables have to be set:
+* `JAVA_VERSION`
+* `ARTIFACTORY_URI`
+* `WEBSTORE_URI`
+* `SLUG_RUNNER_VERSION`
+* `GITHUB_API_USER`
+* `GITHUB_API_TOKEN`
+
+The following environment variables are optional:
+* `INCLUDE_FILES` - a comma separed list of file paths to be included in the root of the slug
 
 Once the variables are set and a fat jar is created, slug can be built by issuing a command:
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2019 HM Revenue & Customs
+# Copyright 2020 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/ArgParser.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/ArgParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/EnvironmentVariables.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/EnvironmentVariables.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,9 @@ object EnvironmentVariables {
   val artifactoryPassword: Either[String, String] = findVariable("ARTIFACTORY_PASSWORD")
   val slugRunnerVersion: Either[String, String]   = findVariable("SLUG_RUNNER_VERSION")
   val jdkFileName: Either[String, String]         = findVariable("JDK_FILE_NAME")
+  val includeFiles: Option[String]                = all.get("INCLUDE_FILES")
   val slugRuntimeJavaOpts: Option[SlugRuntimeJavaOpts] =
-    findVariable("SLUG_RUNTIME_JAVA_OPTS").toOption.map(SlugRuntimeJavaOpts)
+    all.get("SLUG_RUNTIME_JAVA_OPTS").map(SlugRuntimeJavaOpts)
 
   private def findVariable(name: String): Either[String, String] = Either.fromOption(
     all.get(name),

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/Main.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import scala.language.postfixOps
 
 object Main {
 
+  private val progressReporter = new ProgressReporter()
+
   private val slugRunnerVersion    = EnvironmentVariables.slugRunnerVersion.getOrExit
   private val artifactoryUri       = EnvironmentVariables.artifactoryUri.getOrExit
   private val artifactoryUsername  = EnvironmentVariables.artifactoryUsername.getOrExit
@@ -34,11 +36,11 @@ object Main {
   private val jdkFileName          = EnvironmentVariables.jdkFileName.getOrExit
   private val slugRuntimeJavaOpts  = EnvironmentVariables.slugRuntimeJavaOpts
   private val environmentVariables = EnvironmentVariables.all
+  private val includeFiles         = EnvironmentVariables.includeFiles
 
   private implicit val system: ActorSystem    = ActorSystem()
   private implicit val mat: ActorMaterializer = ActorMaterializer()
 
-  private val progressReporter = new ProgressReporter()
   private val httpClient       = StandaloneAhcWSClient()
   private val fileDownloader   = new FileDownloader(httpClient)
   private val artifactoryConnector =
@@ -64,7 +66,7 @@ object Main {
     (ArgParser.parse(args).getOrExit match {
       case Publish(repositoryName, releaseVersion) =>
         slugBuilder
-          .create(repositoryName, releaseVersion, slugRuntimeJavaOpts, environmentVariables)
+          .create(repositoryName, releaseVersion, slugRuntimeJavaOpts, environmentVariables, includeFiles)
       case Unpublish(repositoryName, releaseVersion) =>
         artifactoryConnector
           .unpublish(repositoryName, releaseVersion)

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/Model.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/Model.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/ProgressReporter.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/ProgressReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/SlugBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/SlugBuilder.scala
@@ -129,8 +129,8 @@ class SlugBuilder(
       CREATE_NEW
     )
 
-  private def copyFiles(fileCSV: Option[String], targetDirectory: Path): String =
-    fileCSV.
+  private def copyFiles(optFileCsv: Option[String], targetDirectory: Path): String =
+    optFileCsv.
       fold("No files to copy"){ fileCsv =>
         val files = fileCsv.split(",").map(Paths.get(_))
         files.map(fileUtils.copyFile(_, targetDirectory))

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/SlugBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/SlugBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,50 +43,68 @@ class SlugBuilder(
     repositoryName: RepositoryName,
     releaseVersion: ReleaseVersion,
     slugRuntimeJavaOpts: Option[SlugRuntimeJavaOpts],
-    buildProperties: Map[String, String]): Either[Unit, Unit] = {
+    buildProperties: Map[String, String],
+    includeFiles: Option[String]
+  ): Either[Unit, Unit] = {
 
     val artifact            = ArtifactFileName(repositoryName, releaseVersion)
     val jdk                 = Paths.get("jdk.tgz")
     val workspaceDirectory  = Paths.get(".")
     val slugDirectory       = Paths.get("slug")
-    val startDockerFile     = slugDirectory resolve Paths.get("start-docker.sh")
-    val procFile            = slugDirectory resolve Paths.get("Procfile")
-    val buildPropertiesFile = slugDirectory resolve Paths.get("build.properties")
+    val startDockerFile     = slugDirectory.resolve(Paths.get("start-docker.sh"))
+    val procFile            = slugDirectory.resolve(Paths.get("Procfile"))
+    val buildPropertiesFile = slugDirectory.resolve(Paths.get("build.properties"))
     val slugTgzFile         = Paths.get(artifactoryConnector.slugArtifactFileName(repositoryName, releaseVersion))
     val jdkDirectory        = slugDirectory.resolve(".jdk")
     val profileD            = slugDirectory.resolve(".profile.d")
     val javaSh              = profileD.resolve("java.sh")
 
     for {
-      _ <- verifySlugNotCreatedYet(repositoryName, releaseVersion) map printSuccess
-      _ <- downloadArtifact(repositoryName, releaseVersion, artifact) map printSuccess
-      _ <- downloadAppConfigBase(repositoryName) map printSuccess
-      _ <- perform(createDir(slugDirectory)).leftMap(exception =>
-            s"Couldn't create slug directory at $slugDirectory. Cause: ${exception.getMessage}")
-      _ <- archiver.decompress(Paths.get(artifact.toString), slugDirectory) map printSuccess
+      _ <- verifySlugNotCreatedYet(repositoryName, releaseVersion)
+             .map(printSuccess)
+      _ <- downloadArtifact(repositoryName, releaseVersion, artifact)
+             .map(printSuccess)
+      _ <- downloadAppConfigBase(repositoryName)
+             .map(printSuccess)
+      _ <- perform(createDir(slugDirectory))
+             .leftMap(exception =>
+               s"Couldn't create slug directory at $slugDirectory. Cause: ${exception.getMessage}")
+      _ <- archiver.decompress(Paths.get(artifact.toString), slugDirectory)
+             .map(printSuccess)
       _ <- startDockerScriptCreator.ensureStartDockerExists(
             workspaceDirectory,
             slugDirectory,
             repositoryName,
-            slugRuntimeJavaOpts) map printSuccess
-      _ <- perform(setPermissions(startDockerFile, startDockerPermissions)).leftMap(exception =>
-            s"Couldn't change permissions of the $startDockerFile. Cause: ${exception.getMessage}")
+            slugRuntimeJavaOpts)
+              .map(printSuccess)
+      _ <- perform(setPermissions(startDockerFile, startDockerPermissions))
+             .leftMap(exception =>
+               s"Couldn't change permissions of the $startDockerFile. Cause: ${exception.getMessage}")
       _ <- perform(createFile(procFile, s"web: ./${startDockerFile.toFile.getName}", UTF_8, CREATE_NEW))
             .leftMap(exception => s"Couldn't create the $procFile. Cause: ${exception.getMessage}")
       _ <- perform(
             createFile(buildPropertiesFile, mapToString(removeSensitiveProperties(buildProperties)), UTF_8, CREATE_NEW))
             .leftMap(exception => s"Couldn't create the $buildPropertiesFile. Cause: ${exception.getMessage}")
-      _ <- perform(createDir(jdkDirectory)).leftMap(exception =>
-            s"Couldn't create .jdk directory at $jdkDirectory. Cause: ${exception.getMessage}")
-      _ <- downloadJdk(jdk.toString) map printSuccess
-      _ <- archiver.decompress(jdk, jdkDirectory) map printSuccess
-      _ <- perform(createDir(profileD)).leftMap(exception =>
-            s"Couldn't create $profileD directory. Cause: ${exception.getMessage}")
+      _ <- perform(copyFiles(includeFiles, slugDirectory))
+             .leftMap(exception => s"Couldn't copy include files. Cause: ${exception.getMessage}")
+             .map(printSuccess)
+      _ <- perform(createDir(jdkDirectory))
+             .leftMap(exception =>
+               s"Couldn't create .jdk directory at $jdkDirectory. Cause: ${exception.getMessage}")
+      _ <- downloadJdk(jdk.toString)
+             .map(printSuccess)
+      _ <- archiver.decompress(jdk, jdkDirectory)
+             .map(printSuccess)
+      _ <- perform(createDir(profileD))
+             .leftMap(exception =>
+               s"Couldn't create $profileD directory. Cause: ${exception.getMessage}")
       _ <- perform(createJavaSh(javaSh))
             .leftMap(exception => s"Couldn't create the $javaSh. Cause: ${exception.getMessage}")
             .map(_ => printSuccess(s"Successfully created .profile.d/java.sh"))
-      _ <- archiver.compress(slugTgzFile, slugDirectory) map printSuccess
-      _ <- artifactoryConnector.publish(repositoryName, releaseVersion) map printSuccess
+      _ <- archiver.compress(slugTgzFile, slugDirectory)
+             .map(printSuccess)
+      _ <- artifactoryConnector.publish(repositoryName, releaseVersion)
+             .map(printSuccess)
     } yield ()
   }.leftMap(printError)
 
@@ -111,4 +129,11 @@ class SlugBuilder(
       CREATE_NEW
     )
 
+  private def copyFiles(fileCSV: Option[String], targetDirectory: Path): String =
+    fileCSV.
+      fold("No files to copy"){ fileCsv =>
+        val files = fileCsv.split(",").map(Paths.get(_))
+        files.map(fileUtils.copyFile(_, targetDirectory))
+        s"Copied ${files.map(_.toString).mkString(", ")} into $targetDirectory"
+      }
 }

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/StartDockerScriptCreator.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/StartDockerScriptCreator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/connectors/ArtifactoryConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/connectors/ArtifactoryConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/connectors/FileDownloader.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/connectors/FileDownloader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/tools/CliTools.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/tools/CliTools.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/tools/CommandExecutor.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/tools/CommandExecutor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/tools/FileUtils.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/tools/FileUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,21 @@
 package uk.gov.hmrc.slugbuilder.tools
 
 import java.nio.charset.Charset
-import java.nio.file.{Files, OpenOption, Path}
+import java.nio.file.{Files, OpenOption, Path, Paths}
 import java.nio.file.attribute.PosixFilePermission
 
 import scala.collection.JavaConversions._
 
 class FileUtils {
-  def createDir(dir: Path): Unit = if (Files.exists(dir)) () else dir.toFile.mkdir()
+  def createDir(dir: Path): Unit =
+    if (Files.exists(dir)) () else dir.toFile.mkdir()
 
   def setPermissions(file: Path, permissions: Set[PosixFilePermission]): Unit =
     Files.setPosixFilePermissions(file, permissions)
 
   def createFile(file: Path, content: String, charset: Charset, openOption: OpenOption): Unit =
     Files.write(file, Seq(content), charset, openOption)
+
+  def copyFile(source: Path, targetDirectory: Path): Unit =
+    Files.copy(source, targetDirectory.resolve(source.getFileName))
 }

--- a/src/main/scala/uk/gov/hmrc/slugbuilder/tools/TarArchiver.scala
+++ b/src/main/scala/uk/gov/hmrc/slugbuilder/tools/TarArchiver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This change will allow us to include extra files in the slug. e.g. to include dependency graph: `INCLUDE_FILES=/target/dependencies-compile.dot`